### PR TITLE
sort the list of hosts

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,22 @@
+---
+dependency: []
+
+# This doesn't run in Docker because /etc/hosts is readonly
+driver:
+  name: vagrant
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: host-populate
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  roles:
+    - role: ansible-role-hosts-populate
+      hosts_populate_openstack_groups: [all]

--- a/templates/etc-hosts.j2
+++ b/templates/etc-hosts.j2
@@ -4,7 +4,7 @@
 
 {% for group in (hosts_populate_openstack_groups | default([])) %}
 # Group {{ group }}
-{%   for host in (groups[group] | default([])) %}
+{%   for host in (groups[group] | default([]) | sort) %}
 {{ hostvars[host]['ansible_' + (hosts_populate_iface | default('eth0'))].ipv4.address }} {{ hostvars[host].ansible_hostname }}
 {%   endfor %}
 

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,12 @@
+import testinfra.utils.ansible_runner
+import re
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_index(File):
+    f = File("/etc/hosts")
+    assert re.search(
+        '^# Group all$\n^\d+\.\d+\.\d+\.\d+ host-populate$',
+        f.content, re.MULTILINE)


### PR DESCRIPTION
The lists of hosts in an Ansible group is undefined. This applies the sort filter to ensure idempotency.

Also adds a basic molecule test which only works with Vagrant as `/etc/hosts` is read-only in Docker.

Tag: `0.1.1`